### PR TITLE
Remove arbitrary github urls from Gist matcher

### DIFF
--- a/yara/indicator_suspicious.yar
+++ b/yara/indicator_suspicious.yar
@@ -992,10 +992,9 @@ rule INDICATOR_SUSPICIOUS_EXE_RawGitHub_URL {
         description = "Detects executables containing URLs to raw contents of a Github gist"
     strings:
         $url1 = "https://gist.githubusercontent.com/" ascii wide
-        $url2 = "https://raw.githubusercontent.com/" ascii wide
         $raw = "/raw/" ascii wide
     condition:
-        uint16(0) == 0x5a4d and (($url1 and $raw) or ($url2))
+        uint16(0) == 0x5a4d and ($url1 and $raw)
 }
 
 rule INDICATOR_SUSPICIOUS_EXE_RawPaste_URL {


### PR DESCRIPTION
The gist rule was matching all raw GitHub URLs, which reaches far beyond the gist service.